### PR TITLE
Added admin field with optional guest cart cookie lifetime.

### DIFF
--- a/Helper/Configuration/GuestCookieCartLifetime.php
+++ b/Helper/Configuration/GuestCookieCartLifetime.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace TIG\PersistentShoppingCart\Helper\Configuration;
+
+class GuestCookieCartLifetime extends \Magento\Framework\App\Helper\AbstractHelper
+{
+    const XPATH_CART_COOKIE_LIFETIME = 'tig_persistentshoppingcart/general/guest_cookie_lifetime';
+
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    public function __construct(
+        \Magento\Framework\App\Helper\Context $context,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfigInterface
+    ) {
+        parent::__construct($context);
+
+        $this->scopeConfig = $scopeConfigInterface;
+    }
+
+    public function getGuestCookieLifetimeConfig()
+    {
+        return $this->scopeConfig->getValue(
+            self::XPATH_CART_COOKIE_LIFETIME,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+    }
+}

--- a/Model/AbstractModel.php
+++ b/Model/AbstractModel.php
@@ -66,12 +66,18 @@ abstract class AbstractModel extends FrameworkAbstractModel
     private $helper;
 
     /**
+     * @var \TIG\PersistentShoppingCart\Helper\Configuration\GuestCookieCartLifetime
+     */
+    protected $guestCartCookieConfiguration;
+
+    /**
      * AbstractModel constructor.
      *
      * @param \Magento\Framework\Session\Config\ConfigInterface $sessionConfig
      * @param \Magento\Framework\Stdlib\CookieManagerInterface $cookieManager
      * @param \Magento\Framework\Stdlib\Cookie\CookieMetadataFactory $cookieMetadata
      * @param \TIG\PersistentShoppingCart\Helper\Data $helper
+     * @param \TIG\PersistentShoppingCart\Helper\Configuration\GuestCookieCartLifetime $guestCartCookieConfiguration
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource
@@ -82,6 +88,7 @@ abstract class AbstractModel extends FrameworkAbstractModel
         CookieManagerInterface $cookieManager,
         CookieMetadataFactory $cookieMetadata,
         Helper $helper,
+        \TIG\PersistentShoppingCart\Helper\Configuration\GuestCookieCartLifetime $guestCartCookieConfiguration,
         \Magento\Framework\Model\Context $context,
         \Magento\Framework\Registry $registry,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
@@ -91,6 +98,7 @@ abstract class AbstractModel extends FrameworkAbstractModel
         $this->cookieManager  = $cookieManager;
         $this->cookieMetadata = $cookieMetadata;
         $this->helper         = $helper;
+        $this->guestCartCookieConfiguration = $guestCartCookieConfiguration;
 
         parent::__construct(
             $context,
@@ -182,7 +190,7 @@ abstract class AbstractModel extends FrameworkAbstractModel
     private function processClientCookie($value)
     {
         $metadata = $this->cookieMetadata->createPublicCookieMetadata();
-        $metadata->setDuration($this->sessionConfig->getCookieLifetime());
+        $metadata->setDuration($this->getCookieDuration());
         $metadata->setPath($this->sessionConfig->getCookiePath());
         $metadata->setDomain($this->sessionConfig->getCookieDomain());
 
@@ -193,5 +201,14 @@ abstract class AbstractModel extends FrameworkAbstractModel
         }
 
         $this->cookieManager->deleteCookie($this->cookieName);
+    }
+
+    private function getCookieDuration()
+    {
+        if($this->guestCartCookieConfiguration->getGuestCookieLifetimeConfig() > 0) {
+            return intval($this->guestCartCookieConfiguration->getGuestCookieLifetimeConfig());
+        }
+
+        return $this->sessionConfig->getCookieLifetime();
     }
 }

--- a/Model/QuoteCookie.php
+++ b/Model/QuoteCookie.php
@@ -47,6 +47,9 @@ class QuoteCookie extends AbstractToken
     /** @var \Magento\Framework\App\Config\ScopeConfigInterface */
     private $scopeConfig;
 
+    /** @var \TIG\PersistentShoppingCart\Helper\Configuration\GuestCookieCartLifetime */
+    protected $guestCartCookieConfiguration;
+
     /**
      * Config path to module status
      */
@@ -75,6 +78,7 @@ class QuoteCookie extends AbstractToken
         \Magento\Framework\Stdlib\CookieManagerInterface $cookieManager,
         \Magento\Framework\Stdlib\Cookie\CookieMetadataFactory $cookieMetadata,
         \TIG\PersistentShoppingCart\Helper\Data $helper,
+        \TIG\PersistentShoppingCart\Helper\Configuration\GuestCookieCartLifetime $guestCartCookieConfiguration,
         \Magento\Framework\Model\Context $context,
         \Magento\Framework\Registry $registry,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
@@ -89,6 +93,7 @@ class QuoteCookie extends AbstractToken
             $cookieManager,
             $cookieMetadata,
             $helper,
+            $guestCartCookieConfiguration,
             $context,
             $registry,
             $resource,

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -44,6 +44,10 @@
                 <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 <comment><![CDATA[Make sure Customers > Persistent Shopping Cart > Enable Persistence is set to "Yes" and Persist Shopping Cart is set to "Yes".]]></comment>
             </field>
+            <field id="guest_cookie_lifetime" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Guest Cookie Cart Lifetime</label>
+                <validate>validate-number validate-zero-or-greater</validate>
+            </field>
         </group>
     </section>
 </system>


### PR DESCRIPTION
In one of my projects we needed a way to separate a default magento2 session lifetime from feature offered from your extension. This simple change enables to set dedicated lifetime to guest persistent cookie.